### PR TITLE
Go 1.15.7

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15.6
+        go-version: ^1.15.7
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6 as builder
+FROM golang:1.15.7 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.15
> go1.15.7 (planned for 2021/01/19) will include security fixes.