### PR TITLE
use io package instead of ioutil package

### DIFF
--- a/infrastructure/mflight/httpclient/client.go
+++ b/infrastructure/mflight/httpclient/client.go
@@ -3,7 +3,7 @@ package httpclient
 import (
 	"context"
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -50,7 +50,7 @@ func (c *client) GetSensorMonitor(ctx context.Context) (*Response, error) {
 	}
 	defer resp.Body.Close()
 
-	byteArray, err := ioutil.ReadAll(resp.Body)
+	byteArray, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &Response{}, nil
 	}


### PR DESCRIPTION
Go 1.16 から `ioutil` パッケージが `io` と `os` に分かれたため

`util` は名前が良くないからやめようぜ、ということらしい